### PR TITLE
Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:2.6
+FROM ruby:2.6-alpine
 
-RUN apt-get update && apt-get install -y python3-pip
+RUN apk add python3 make g++ git
 RUN pip3 install --upgrade yamllint
 
 ENV HOME /overcommit


### PR DESCRIPTION
Using ruby:2.6-alpine decreases the image size from 1.04GB to 342MB.

In comparison, ruby:2.6-slim occupies 647MB while replacing the base image to python:3-alpine results in 360MB.