### PR TITLE
Add golangci-lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM bitnami/jsonnet:0.18.0 as jsonnet
+FROM golangci/golangci-lint:v1.50.0 as golangci-lint
 FROM ruby:3.1-alpine
 
 COPY --from=jsonnet /opt/bitnami/jsonnet/bin/jsonnetfmt /usr/local/bin
+COPY --from=golangci-lint /usr/bin/golangci-lint /usr/local/bin
 
 RUN apk add --no-cache --update \
       bash \


### PR DESCRIPTION
This commit will add the golangci-lint binary to the Docker image. 